### PR TITLE
Add Safety model README section and MCP registry server.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,18 @@ That last one uses `pcb_get_rule_properties`, which returns the actual numeric g
 
 Bulk tools like `obj_batch_modify`, `pcb_move_components`, and `sch_place_components` finish the whole operation in one IPC round-trip.
 
+## Safety model
+
+eda-agent edits a live EDA session, so a number of tools are necessarily destructive in the same way your delete key is. Automated MCP catalogues sometimes flag the server on the raw count of destructive-class tools; here is what actually bounds the blast radius:
+
+- **Local only.** Tools operate on the EDA application over a local file-based IPC bridge. The server has no network egress, reads no credentials, and executes no arbitrary code on the host.
+- **Checkpoints.** `app_checkpoint` / `app_restore_checkpoint` snapshot the open project before risky operations, and `app_list_checkpoints` shows what you can roll back to.
+- **Allow-listable surface.** Every write tool is separately named, so MCP clients can allow-list read-only operation (`*_get_*`, `audit_*`, `review_*`, render and export tools) and deny or require approval on everything else. A sensible policy: allow read/audit/render, require approval on writes, deny destructive tools you do not use.
+- **Minimal toolset mode.** `--toolset minimal` (or `EDA_AGENT_TOOLSET=minimal`) advertises only `tool_catalog` and `tool_invoke` for clients that cap tool counts.
+- **Back up first.** The scripting engine underneath can be crashed by edge cases (see [Known limitations](#known-limitations)); treat any design you point the agent at as you would before running any script on it.
+
+Vulnerability reports: see [SECURITY.md](SECURITY.md).
+
 ## Known limitations
 
 **This tool is experimental. Please read this section before using on a design you haven't backed up.**

--- a/server.json
+++ b/server.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.json",
+  "name": "io.github.salitronic/eda-agent",
+  "description": "Drive a live Altium Designer, KiCad or EasyEDA Pro session with AI. 300+ tools: schematic, PCB, library and project automation, design review, audits, rendering, auto-placement, panelization.",
+  "repository": {
+    "url": "https://github.com/salitronic/eda-agent",
+    "source": "github"
+  },
+  "version": "0.5.0"
+}


### PR DESCRIPTION
﻿Two promotion-readiness changes:

**README: new "Safety model" section** (placed before Known limitations). Context: PolicyLayer's automated MCP catalogue currently grades eda-agent "Risk F" purely on the count of destructive-class tools, and that page ranks second on Google for the project name. This section states the actual security posture in one place: local-only bridge with no network egress, checkpoint/restore, per-tool allow-listing with a recommended policy, minimal toolset mode, and the existing back-up-first warning. It also links SECURITY.md.

**server.json** for the Official MCP Registry (io.github.salitronic namespace, v0.5.0, repository-source). To publish after merging: mcp-publisher login github, then mcp-publisher publish. Note: the registry favors installable packages; if the CLI asks for one, publishing eda-agent to PyPI first (enables uvx eda-agent) and adding a packages block is the clean path. PulseMCP states they auto-ingest from the official registry, which gets the directory listing for free.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjRnm12cYY9NJbmHgymsr8
